### PR TITLE
Add alt attributes for image accessibility

### DIFF
--- a/src/app/(pages)/admin/adv/img/page.tsx
+++ b/src/app/(pages)/admin/adv/img/page.tsx
@@ -54,7 +54,7 @@ const AdminImgAdvPage: React.FC = () => {
                                 <tr key={item._id}>
                                     <td>{item.advId}</td>
                                     <td>{item.advName}</td>
-                                    <td><Image src={item.imgURL} alt={item.imgAlt || item.advName} width={56} height={56} className="rounded w-14 h-14"/></td>
+                                    <td><Image src={item.imgURL} alt={item.imgAlt || ""} width={56} height={56} className="rounded w-14 h-14"/></td>
                                     <td className="hidden lg:block">{item.body}</td>
                                     <td>
                                         <Link href={`${RouteConfig.admin.adv.img.base}/${item._id}`}>

--- a/src/app/(pages)/admin/components/forms/EditAdvImgForm.tsx
+++ b/src/app/(pages)/admin/components/forms/EditAdvImgForm.tsx
@@ -104,7 +104,10 @@ const EditAdvImgForm = ({ data }: { data: ImgAdvCashType }) => {
               value={formData.imgAlt}
               color="input-primary"
               onChange={handler.trakeChange}
+              placeholder="Describe the image for accessibility (alt text)"
+              tooltip="Alt text helps screen readers describe images. If left blank, the image will be ignored by screen readers."
             />
+            <div className="text-xs text-warning mb-2">Alt text is important for accessibility. Please provide a meaningful description, or leave blank if the image is decorative.</div>
             <Button type="submit" color="btn-primary" className="w-full block md:hidden" >
               {EDITMODE ? "Save" : "create"}
             </Button>

--- a/src/app/(pages)/admin/components/forms/EditMapsForm.tsx
+++ b/src/app/(pages)/admin/components/forms/EditMapsForm.tsx
@@ -35,6 +35,7 @@ const EditMapsForm = ({ post }: { post: MapsCashType }) => {
     country: EDITMODE ? post.country : "1",
     province: EDITMODE ? post.province : "1",
     imgurl: EDITMODE ? post.imgurl : "",
+    imgAlt: EDITMODE ? post.imgAlt : "",
     source: EDITMODE ? post.source : "",
     author: master ? "masterEditor" : EDITMODE ? post.author : "",
   };
@@ -121,9 +122,23 @@ const EditMapsForm = ({ post }: { post: MapsCashType }) => {
         <div className="w-full md:w-1/2">
           <ImagePreview
             imgurl={formData.imgurl}
+            alt={formData.imgAlt}
             title={formData.title}
             onChange={handler.trakeChange}
           />
+          <Input
+            type="text"
+            id="imgAlt"
+            name="imgAlt"
+            label="Image Alt Text"
+            className="w-full mb-2"
+            color="input-primary"
+            value={formData.imgAlt}
+            onChange={handler.trakeChange}
+            placeholder="Describe the image for accessibility (alt text)"
+            tooltip="Alt text helps screen readers describe images. If left blank, the image will be ignored by screen readers."
+          />
+          <div className="text-xs text-warning mb-2">Alt text is important for accessibility. Please provide a meaningful description, or leave blank if the image is decorative.</div>
           <div id="tiptap-style">
             <label htmlFor="body" className="label">
               Body

--- a/src/app/(pages)/admin/components/forms/EditPostForm.tsx
+++ b/src/app/(pages)/admin/components/forms/EditPostForm.tsx
@@ -32,6 +32,7 @@ const EditPostForm = ({ post }: { post: PostsCashType }) => {
     section: EDITMODE ? post.section : "1",
     services: EDITMODE ? post.services : "1",
     imgurl: EDITMODE ? post.imgurl : "",
+    imgAlt: EDITMODE ? post.imgAlt : "",
     categories: EDITMODE ? post.categories ?? [] : [],
     masterEditor: master ? true : false,
     source: EDITMODE ? post.source : "",
@@ -162,9 +163,23 @@ const EditPostForm = ({ post }: { post: PostsCashType }) => {
         <div className="w-full md:w-1/2">
           <ImagePreview
             imgurl={formData.imgurl}
+            alt={formData.imgAlt}
             title={formData.title}
             onChange={handler.trakeChange}
           />
+          <Input
+            type="text"
+            id="imgAlt"
+            name="imgAlt"
+            label="Image Alt Text"
+            className="w-full mb-2"
+            color="input-primary"
+            value={formData.imgAlt}
+            onChange={handler.trakeChange}
+            placeholder="Describe the image for accessibility (alt text)"
+            tooltip="Alt text helps screen readers describe images. If left blank, the image will be ignored by screen readers."
+          />
+          <div className="text-xs text-warning mb-2">Alt text is important for accessibility. Please provide a meaningful description, or leave blank if the image is decorative.</div>
           <div id="tiptap-style">
             <label htmlFor="body" className="label">
               Body

--- a/src/app/(pages)/admin/components/shared/ImagePreview.tsx
+++ b/src/app/(pages)/admin/components/shared/ImagePreview.tsx
@@ -4,17 +4,19 @@ import { FaLink } from "react-icons/fa";
 
 const ImagePreview = ({
   imgurl,
+  alt = "",
   title,
   onChange,
 }: {
   imgurl: string;
+  alt?: string;
   title: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) => (
   <>
     <Image
       src={!imgurl ? "/static/Image/logo.jpg" : imgurl}
-      alt={title}
+      alt={typeof alt === "string" ? alt : ""}
       title={title}
       height={390.938}
       width={695}

--- a/src/app/(pages)/posts/[id]/components/NewsBody.tsx
+++ b/src/app/(pages)/posts/[id]/components/NewsBody.tsx
@@ -32,7 +32,7 @@ const NewsBody = ({ post }: { post: any }) => {
         className="aspect-video w-full rounded-3xl py-3"
         src={!post.imgurl ? "/static/Image/logo.jpg" : post.imgurl}
         title={post.title}
-        alt={post.title}
+        alt={post.imgAlt || ""}
         width={662.172}
         height={372.469}
         loading="eager"

--- a/src/components/organisms/postsSection/MainItem.tsx
+++ b/src/components/organisms/postsSection/MainItem.tsx
@@ -16,7 +16,7 @@ const MainItem = ({ post }: { post: PostsCashType }) => {
           >
             <Image
               src={!post.imgurl ? "/static/Image/logo.jpg" : post.imgurl}
-              alt={post.title}
+              alt={post.imgAlt || ""}
               title={post.title.slice(0, 60)}
               width={500}
               height={270}

--- a/src/components/organisms/postsSection/PostCard.tsx
+++ b/src/components/organisms/postsSection/PostCard.tsx
@@ -12,7 +12,7 @@ const PostCard = ({ post }: { post: any }) => {
           <figure className="px-5 pt-5">
             <Image
               src={!post.imgurl ? "/static/Image/logo.jpg" : post.imgurl}
-              alt=""
+              alt={post.imgAlt || ""}
               width={662.172}
               height={372.469}
               loading='lazy'

--- a/src/components/organisms/sections/CTA.tsx
+++ b/src/components/organisms/sections/CTA.tsx
@@ -12,15 +12,15 @@ function CTA() {
                         <h2 className="text-base font-semibold text-indigo-400 tracking-wide uppercase">Get started
                             now</h2>
                         <div className="inline-flex items-end justify-center w-full text-center mx-auto">
-                            <Image src="/static/Image/user1.jpg" width={48} height={48} alt=''
+                            <Image src="/static/Image/user1.jpg" width={48} height={48} alt="User 1 avatar"
                                  className="absolute transform translate-x-24 ml-6 rounded-full w-12 h-12 md:w-16 md:h-16 border-4 border-white"/>
-                            <Image src="/static/Image/user2.jpg" width={48} height={48} alt=''
+                            <Image src="/static/Image/user2.jpg" width={48} height={48} alt="User 2 avatar"
                                  className="absolute transform -translate-x-24 -ml-6 rounded-full w-12 h-12 md:w-16 md:h-16 border-4 border-white"/>
-                            <Image src="/static/Image/user3.webp" width={48} height={48} alt=''
+                            <Image src="/static/Image/user3.webp" width={48} height={48} alt="User 3 avatar"
                                  className="absolute transform -translate-x-16 rounded-full w-16 h-16 md:w-20 md:h-20 border-4 border-white"/>
-                            <Image src="/static/Image/user4.webp" width={48} height={48} alt=''
+                            <Image src="/static/Image/user4.webp" width={48} height={48} alt="User 4 avatar"
                                  className="absolute transform translate-x-16 rounded-full w-16 h-16 md:w-20 md:h-20 border-4 border-white"/>
-                            <Image src="/static/Image/user5.webp" width={48} height={48} alt=''
+                            <Image src="/static/Image/user5.webp" width={48} height={48} alt=""
                                  className="rounded-full w-20 h-20 md:w-24 md:h-24 border-4 border-white relative"/>
                         </div>
                         <p className="mt-1 text-4xl font-extrabold sm:text-5xl sm:tracking-tight lg:text-6xl">Discover

--- a/src/models/model/Maps.ts
+++ b/src/models/model/Maps.ts
@@ -18,6 +18,11 @@ const mapsSchema = new Schema(
             type: String,
             required: true,
         },
+        imgAlt: {
+            type: String,
+            trim: true,
+            default: ""
+        },
         country: {
             type: String,
             trim: true,

--- a/src/models/model/Post.ts
+++ b/src/models/model/Post.ts
@@ -8,6 +8,7 @@ import { defaultSchemaOptions } from "../schemaOptions"; // Importing default sc
  * @typedef {Object} PostSchema
  * @property {string} title - The title of the post. Should be a non-empty string.
  * @property {string} imgurl - The URL of the image associated with the post. Must be a valid URL.
+ * @property {string} imgAlt - The alternative text for the image associated with the post.
  * @property {string} description - A brief description of the post.
  * @property {string} section - The section or category the post belongs to.
  * @property {string} services - The services related to the post.
@@ -30,6 +31,11 @@ const postSchema = new Schema(
     imgurl: {
       type: String,
       required: true,
+    },
+    imgAlt: {
+      type: String,
+      trim: true,
+      default: ""
     },
     description: {
       type: String,


### PR DESCRIPTION
# Add alt text support and accessibility warnings for images

## Description

This PR implements the following accessibility improvements for images throughout the application:

- **Alt Text Support:**  
  Users can now provide alt text for images when uploading or editing content (Posts, Maps, Adv Images).
- **Default Alt Attribute:**  
  If no alt text is provided, the `alt` attribute is set to an empty string (`alt=""`), ensuring decorative images are skipped by screen readers.
- **User Guidance:**  
  The image upload/edit forms now include tooltips and warning messages to inform users about the importance of alt text for accessibility.
- **Model Updates:**  
  The `Post` and `Maps` models now support storing `imgAlt` (alt text) for images.
- **UI Updates:**  
  All usages of the `<Image />` component have been updated to use the correct alt text logic.

## Motivation

- Ensures all images are accessible to users relying on screen readers.
- Fulfills [Issue #80](https://github.com/your-org/your-repo/issues/80):  
  > “Currently, the application does not handle alt text for images in a way that ensures accessibility for screen readers...”

## Acceptance Criteria

- [x] All image tags include an `alt` attribute.
- [x] If no alt text is provided, `alt=""` is used.
- [x] Users are informed about the importance of alt text via tooltips or warnings.
- [x] Feature tested with screen readers to confirm images without alt text are properly skipped.

## Screenshots

<!-- Optionally add screenshots of the new alt text input and warning in the UI -->

## Checklist

- [x] Code builds and runs locally
- [x] Accessibility tested
- [x] All relevant models and forms updated
- [x] PR references and closes #80

---

Closes #80