### PR TITLE
 Now shows toast error in services admin

### DIFF
--- a/src/app/(pages)/admin/components/forms/EditServicesForm.tsx
+++ b/src/app/(pages)/admin/components/forms/EditServicesForm.tsx
@@ -25,15 +25,18 @@ const EditServicesForm = ({ data }: { data: ServicesCashType }) => {
   const { data: services } = useFetch(SERVICES_QUERY_KEY, SERVICES_API_URL);
 
   const handler = new FormHandler(setFormData, SERVICES_API_URL, router);
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) =>
-    services.map((service: ServicesCashType) => {
-      if (service.secid === formData.secid) {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!EDITMODE) {
+      // Only check for duplicate secid when creating
+      const duplicate = services?.some((service: ServicesCashType) => service.secid === formData.secid);
+      if (duplicate) {
         toast.error("Service id already exist try another");
-        e.preventDefault();
-      } else {
-        handler.submit(e, formData, data._id);
+        return;
       }
-    });
+    }
+    handler.submit(e, formData, data._id);
+  };
 
   return (
     <>


### PR DESCRIPTION
# Show Toast Error for Duplicate Service ID in Admin Services

## Description
This PR improves the user experience when creating a new service in the admin panel. Now, if the entered `secid` matches an existing service, a toast error is shown and the form submission is prevented. This allows the user to try a different ID without sending an unnecessary request to the server.

## Changes
- Updated the `EditServicesForm` component:
  - On service creation, checks if the `secid` already exists among current services.
  - If a duplicate is found, displays a toast error: `Service id already exist try another` and blocks submission.
  - If no duplicate, proceeds with the normal submission flow.
  - Edit mode (updating an existing service) is unaffected and always allows submission.

## Motivation
Previously, attempting to create a service with a duplicate `secid` could result in confusing behavior or unnecessary server requests. This change provides immediate feedback to the user and prevents duplicate IDs at the UI level.

## How to Test
1. Go to the admin services creation page.
2. Try to create a new service with a `secid` that already exists.
3. You should see a toast error and the form will not submit.
4. Try with a unique `secid` and the service should be created as normal.

---

Closes #92
